### PR TITLE
fixup: Documentation refered to wrong default values

### DIFF
--- a/catppuccinpalette.dtx
+++ b/catppuccinpalette.dtx
@@ -131,11 +131,11 @@
 %   \\
 %   \verb|textcolor| &
 %   set the default textcolor of the document to \verb|CtpText|. Possible values:
-%   \verb|false| (default+initial), \verb|true|
+%   \verb|false| (initial), \verb|true| (default)
 %   \\
 %   \verb|pagecolor| &
 %   set the pagecolor of the document to \verb|CtpBackground|. Possible values:
-%   \verb|false| (default+initial), \verb|true|
+%   \verb|false| (initial), \verb|true| (default)
 %   \\
 %   \verb|hyperref| &
 %   style hyperref according to the style guide\footnote{\url{https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md\#typography}}.

--- a/latex.tera
+++ b/latex.tera
@@ -123,11 +123,11 @@ versionDate:
 %   \\
 %   \verb|textcolor| &
 %   set the default textcolor of the document to \verb|CtpText|. Possible values:
-%   \verb|false| (default+initial), \verb|true|
+%   \verb|false| (initial), \verb|true| (default)
 %   \\
 %   \verb|pagecolor| &
 %   set the pagecolor of the document to \verb|CtpBackground|. Possible values:
-%   \verb|false| (default+initial), \verb|true|
+%   \verb|false| (initial), \verb|true| (default)
 %   \\
 %   \verb|hyperref| &
 %   style hyperref according to the style guide\footnote{\url{https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md\#typography}}.


### PR DESCRIPTION
See title.

Note: In `pgfkeys` terms, there are two things:
- *initial*: this is the value the option has if you do nothing
- *default*: this is the *default* value that gets passed when you specify the option, but don't pass a value to it