### PR TITLE
ci: update setup-whiskers

### DIFF
--- a/.github/workflows/whiskers.yml
+++ b/.github/workflows/whiskers.yml
@@ -1,22 +1,16 @@
-name: check whiskers
+name: whiskers
 
 on:
+  workflow_dispatch:
   push:
     branches: ["main"]
   pull_request:
     branches: ["main"]
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Whiskers
-        uses: catppuccin/setup-whiskers@v1
-        with:
-          whiskers-version: 2.5.1
-
-      - name: Check if whiskers generated same file
-        run: |
-          whiskers --check catppuccinpalette.dtx latex.tera
+      - uses: catppuccin/setup-whiskers@v2
+      - run: whiskers --check catppuccinpalette.dtx latex.tera

--- a/latex.tera
+++ b/latex.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-    version: 2.5.1
+    version: ^2.5.1
     filename: "catppuccinpalette.dtx"
 
 packageVersion: 1.1.0


### PR DESCRIPTION
We can't fully use the reusable workflow yet but at least we can get rid of hard-coding the version now :+1:
Note that whiskers will soon start to recommend ^ in front of the version.