### PR TITLE
bump version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ need to pass `hyperref=true` to `\usepackage{catppuccinpalette}` (after
 
 Please refer to the [examples](https://github.com/catppuccin/latex/tree/main/examples) for full demonstrations, with LaTeX sources and their outputs, on theme usage and code highlighting.
 
+## Developing
+<details>
+<summary>How to do a new release</summary>
+
+1. adjust the version tag in the `latex.tera` and `beamercolorthemecatppuccin.dtx` files
+2. add the changelog entry also in those two files (I'd say we just skip the entry if for the specific package/file nothing was changed now that we have two packages/files)
+3. run `make whiskers`
+4. PR -> merge -> tag the commit (conforming to `"v*.*.*"` and the release will be created automatically)
+
+</details>
+
 ## 💝 Thanks to
 
 - [Lukas](https://github.com/atticus-sullivan)

--- a/beamercolorthemecatppuccin.dtx
+++ b/beamercolorthemecatppuccin.dtx
@@ -31,7 +31,7 @@
 %<package>\NeedsTeXFormat{LaTeX2e}[1999/12/01]
 %<package>\ProvidesPackage{beamercolorthemecatppuccin}
 %<*package>
-    [2024/02/27 v1.0.0 catppuccin beamer color theme]
+    [2025/07/19 v1.2.0 catppuccin beamer color theme]
 %</package>
 %
 %<*driver>
@@ -71,6 +71,7 @@
 %
 % \changes{v0.0.1}{2024/02/25}{Converted to DTX file}
 % \changes{v1.0.0}{2024/02/27}{First full release}
+% \changes{v1.2.0}{2025/07/19}{Merge with official catppuccin package}
 %
 % \DoNotIndex{\newcommand,\newenvironment,\@ifclassloaded,\def,\renewcommand,\RequirePackage,\setbeamercolor,\usebeamercolor,\ProvidesPackage,\DeclareOptionBeamer,\ExecuteOptionsBeamer,\ProcessOptionsBeamer,\mode}
 %

--- a/catppuccinpalette.dtx
+++ b/catppuccinpalette.dtx
@@ -31,7 +31,7 @@
 %<package>\NeedsTeXFormat{LaTeX2e}[1999/12/01]
 %<package>\ProvidesPackage{catppuccinpalette}
 %<*package>
-    [2024/08/13 v1.1.0 catppuccin xcolor palette]
+    [2025/07/19 v1.2.0 catppuccin xcolor palette]
 %</package>
 %
 %<*driver>
@@ -75,6 +75,7 @@
 % \changes{v1.0.1}{2024/05/19}{Make fit for CTAN}
 % \changes{v1.0.2}{2024/05/19}{Fix colors in documentation}
 % \changes{v1.1.0}{2024/08/13}{Move to / Merge with official catppuccin. Thereby deprecate colors with |Cat| prefix. Subject to removal in the future}
+% \changes{v1.2.0}{2025/07/19}{Add suport for beamer}
 %
 % \DoNotIndex{\newcommand,\newenvironment,\color,\colorlet,\def,\fi,\RequirePackage,\ProvidesPackage,\ProcessPgfOptions,\preparecolorset,\pgfkeys,\pagecolor,\newif,\NeedsTeXFormat}
 %

--- a/latex.tera
+++ b/latex.tera
@@ -3,11 +3,11 @@ whiskers:
     version: ^2.5.1
     filename: "catppuccinpalette.dtx"
 
-packageVersion: 1.1.0
+packageVersion: 1.2.0
 versionDate:
-    year: 2024
-    month: 08
-    day: 13
+    year: 2025
+    month: 07
+    day: 19
 
 ---
 % \iffalse meta-comment
@@ -67,6 +67,7 @@ versionDate:
 % \changes{v1.0.1}{2024/05/19}{Make fit for CTAN}
 % \changes{v1.0.2}{2024/05/19}{Fix colors in documentation}
 % \changes{v1.1.0}{2024/08/13}{Move to / Merge with official catppuccin. Thereby deprecate colors with |Cat| prefix. Subject to removal in the future}
+% \changes{v1.2.0}{2025/07/19}{Add suport for beamer}
 %
 % \DoNotIndex{\newcommand,\newenvironment,\color,\colorlet,\def,\fi,\RequirePackage,\ProvidesPackage,\ProcessPgfOptions,\preparecolorset,\pgfkeys,\pagecolor,\newif,\NeedsTeXFormat}
 %


### PR DESCRIPTION
Adjusting the dates and version identifiers so we can release a new version (and upload to ctan).

@sgoudham you should be able to upload to [ctan](https://ctan.org/pkg/catppuccinpalette) as well, do we want to try it this time? (else I can also do the upload, but I'll be unavailable for the next weak).

Other packages providing themes for latex beamer (like [1](https://ctan.org/pkg/beamer-verona) or [2](https://ctan.org/pkg/beamer-theme-albi) (random selection)) have the topic/tag *Presentation*. Maybe we want this also set that one (just a field in the upload form).

Also should we document somewhere what to do in case of a new release (or so these version bump commits suffice as some sort of documentation)? So far it should be
1. adjust the version tag in the `latex.tera` and `beamercolorthemecatppuccin.dtx` files
2. add the changelog entry also in those two files (I'd say we just skip the entry if for the specific package/file nothing was changed now that we have two packages/files)
3. run `make whiskers`