### PR TITLE
chore: make use of l3build's capability of automatically adjusting the version-tag + date

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Please refer to the [examples](https://github.com/catppuccin/latex/tree/main/exa
 <details>
 <summary>How to do a new release</summary>
 
-1. adjust the version tag in the `latex.tera` and `*.dtx` files -- can be done automatically by running `l3build tag <version>` (e.g. `l3build tag 1.3.0`)
+1. adjust the version tag in the `latex.tera` and `beamercolorthemecatppuccin.dtx` files. This can also be done automatically by running `l3build tag <version>` (e.g. `l3build tag 1.3.0`)
 2. add the changelog entry also in those two files (I'd say we just skip the entry if for the specific package/file nothing was changed now that we have two packages/files)
 3. run `make whiskers`
 4. PR -> merge -> tag the commit (conforming to `"v*.*.*"` and the release will be created automatically)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Please refer to the [examples](https://github.com/catppuccin/latex/tree/main/exa
 <details>
 <summary>How to do a new release</summary>
 
-1. adjust the version tag in the `latex.tera` and `beamercolorthemecatppuccin.dtx` files
+1. adjust the version tag in the `latex.tera` and `*.dtx` files -- can be done automatically by running `l3build tag <version>` (e.g. `l3build tag 1.3.0`)
 2. add the changelog entry also in those two files (I'd say we just skip the entry if for the specific package/file nothing was changed now that we have two packages/files)
 3. run `make whiskers`
 4. PR -> merge -> tag the commit (conforming to `"v*.*.*"` and the release will be created automatically)

--- a/beamercolorthemecatppuccin.dtx
+++ b/beamercolorthemecatppuccin.dtx
@@ -29,10 +29,7 @@
 \ProvidesFile{beamercolorthemecatppuccin.dtx}
 %</driver>
 %<package>\NeedsTeXFormat{LaTeX2e}[1999/12/01]
-%<package>\ProvidesPackage{beamercolorthemecatppuccin}
-%<*package>
-    [2025/07/19 v1.2.0 catppuccin beamer color theme]
-%</package>
+%<package>\ProvidesPackage{beamercolorthemecatppuccin}[2025-07-19 v1.2.0 catppuccin beamer color theme]
 %
 %<*driver>
 \documentclass{ltxdoc}

--- a/build.lua
+++ b/build.lua
@@ -1,2 +1,19 @@
 module = "catppuccinpalette"
 excludefiles = {".link.md", "*~","build.lua","config-*.lua"}
+
+tagfiles = {"*.dtx", "latex.tera"}
+
+function update_tag(filename, content, tagname, tagdate)
+	if filename == "catppuccinpalette.dtx" then
+		return string.gsub(content, "\n(%%<package>\\ProvidesPackage{catppuccinpalette})%[%d%d%d%d%-%d%d%-%d%d% v%d+%.%d+%.%d+% (.*)]\n", "\n%1["..tagdate.." v"..tagname.." %2]\n")
+	elseif filename == "beamercolorthemecatppuccin.dtx" then
+		return string.gsub(content, "\n(%%<package>\\ProvidesPackage{beamercolorthemecatppuccin})%[%d%d%d%d%-%d%d%-%d%d% v%d+%.%d+%.%d+% (.*)]\n", "\n%1["..tagdate.." v"..tagname.." %2]\n")
+	elseif filename == "latex.tera" then
+		local tagyear, tagmonth, tagday = tagdate:match("(%d%d%d%d)%-(%d%d)%-(%d%d)")
+		return string.gsub(
+			content,
+			"\npackageVersion: 1.2.0\nversionDate:\n    year: \"2025\"\n    month: \"07\"\n    day: \"19\"",
+			"\npackageVersion: "..tagname.."\nversionDate:\n    year: \""..tagyear.."\"\n    month: \""..tagmonth.."\"\n    day: \""..tagday.."\""
+		)
+	end
+end

--- a/catppuccinpalette.dtx
+++ b/catppuccinpalette.dtx
@@ -29,10 +29,7 @@
 \ProvidesFile{catppuccinpalette.dtx}
 %</driver>
 %<package>\NeedsTeXFormat{LaTeX2e}[1999/12/01]
-%<package>\ProvidesPackage{catppuccinpalette}
-%<*package>
-    [2025/07/19 v1.2.0 catppuccin xcolor palette]
-%</package>
+%<package>\ProvidesPackage{catppuccinpalette}[2025-07-19 v1.2.0 catppuccin xcolor palette]
 %
 %<*driver>
 \documentclass{ltxdoc}

--- a/latex.tera
+++ b/latex.tera
@@ -21,10 +21,7 @@ versionDate:
 \ProvidesFile{catppuccinpalette.dtx}
 %</driver>
 %<package>\NeedsTeXFormat{LaTeX2e}[1999/12/01]
-%<package>\ProvidesPackage{catppuccinpalette}
-%<*package>
-    [{{versionDate.year}}-{{versionDate.month}}-{{versionDate.day}} v{{ packageVersion }} catppuccin xcolor palette]
-%</package>
+%<package>\ProvidesPackage{catppuccinpalette}[{{versionDate.year}}-{{versionDate.month}}-{{versionDate.day}} v{{ packageVersion }} catppuccin xcolor palette]
 %
 %<*driver>
 \documentclass{ltxdoc}

--- a/latex.tera
+++ b/latex.tera
@@ -5,9 +5,9 @@ whiskers:
 
 packageVersion: 1.2.0
 versionDate:
-    year: 2025
-    month: 07
-    day: 19
+    year: "2025"
+    month: "07"
+    day: "19"
 
 ---
 % \iffalse meta-comment
@@ -23,7 +23,7 @@ versionDate:
 %<package>\NeedsTeXFormat{LaTeX2e}[1999/12/01]
 %<package>\ProvidesPackage{catppuccinpalette}
 %<*package>
-    [{{versionDate.year}}/{{versionDate.month}}/{{versionDate.day}} v{{ packageVersion }} catppuccin xcolor palette]
+    [{{versionDate.year}}-{{versionDate.month}}-{{versionDate.day}} v{{ packageVersion }} catppuccin xcolor palette]
 %</package>
 %
 %<*driver>


### PR DESCRIPTION
goal: use `l3build tag` to quickly adjust the version tags

for this
1. reformat the `\ProvidesPackage` lines to make sure `l3build` only identifies the correct line(s)
2. reformat the date specifies for `yyyy-mm-dd`
3. use strings in `latex.tera` (avoids potential issues with octal interpreting of `09` as it is simple yaml)

Todos:
 - [x] increment the release number (right before merging)